### PR TITLE
Added missing `lxml` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-dependencies = ["requests>=2.22.0", "beautifulsoup4>=4.4.0"]
+dependencies = ["requests>=2.22.0", "beautifulsoup4>=4.4.0", "lxml>=4.9.2"]
 
 
 def read_version(module_name):


### PR DESCRIPTION
In order to use the `lxml` parser from bs4 it needs to be installed aswell: https://github.com/meyt/linkpreview#use-lxml-as-xml-parser