### PR TITLE
Optionally pass the Beautiful Soup object to constructors

### DIFF
--- a/linkpreview/linkpreview.py
+++ b/linkpreview/linkpreview.py
@@ -1,4 +1,7 @@
 from os.path import dirname
+from typing import Union
+
+from bs4 import BeautifulSoup
 
 from linkpreview.link import Link
 from linkpreview.preview import (
@@ -14,13 +17,13 @@ PARSER = "html.parser"
 
 
 class LinkPreview:
-    def __init__(self, link: Link, parser: str = PARSER):
+    def __init__(self, link: Link, parser: Union[str, None] = PARSER, soup: Union[BeautifulSoup, None] = None):
         self.link = link
-        self.generic = Generic(link, parser)
-        self.opengraph = OpenGraph(link, parser)
-        self.twitter = TwitterCard(link, parser)
-        self.microdata = Microdata(link, parser)
-        self.jsonld = JsonLd(link, parser)
+        self.generic = Generic(link, parser, soup)
+        self.opengraph = OpenGraph(link, parser, soup)
+        self.twitter = TwitterCard(link, parser, soup)
+        self.microdata = Microdata(link, parser, soup)
+        self.jsonld = JsonLd(link, parser, soup)
 
     @LazyAttribute
     def sources(self):

--- a/linkpreview/preview/base.py
+++ b/linkpreview/preview/base.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 from bs4 import BeautifulSoup
 from linkpreview.link import Link
 
@@ -7,9 +9,16 @@ class PreviewBase(object):  # pragma: nocover
     Base for all web preview.
     """
 
-    def __init__(self, link: Link, parser: str):
+    def __init__(self, link: Link, parser: Union[str, None] = None, soup: Union[BeautifulSoup, None] = None):
+        if parser and soup:
+            raise Exception(
+                'Only one of `parser` or `soup` argument must be provided to PreviewBase')
+
         self.link = link
-        self._soup = BeautifulSoup(self.link.content, parser)
+        if soup:
+            self._soup = soup
+        else:
+            self._soup = BeautifulSoup(self.link.content, parser)
 
     @property
     def title(self):

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 
 from linkpreview import Link
 from linkpreview.preview import Generic
@@ -113,6 +114,23 @@ def test_generic(tin, tout):
     preview = Generic(link, parser="html.parser")
     for key in tout.keys():
         assert getattr(preview, key) == tout[key]
+
+
+def test_bs4_object():
+    link = Link("http://localhost")
+    content = get_sample("generic/title.html")
+    bs_content = BeautifulSoup(content, "html.parser")
+    preview = Generic(link, soup=bs_content)
+    assert preview.title == "This title is at the title tag."
+    assert preview.description is None
+    assert preview.image is None
+
+
+def test_invalid_arguments():
+    link = Link("http://localhost")
+    bs_content = BeautifulSoup()
+    with pytest.raises(Exception):
+        Generic(link, parser="html.parser", soup=bs_content)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Hi!

Thanks for this nice library! I would like to integrate it into the [Sosse](https://gitlab.com/biolds1/sosse) project, a search engine and crawler I'm writing. In this context, I'm extracting the preview while I already have a Soup object with the web page content. So, here is a small patch that permits passing the Soup object without parsing the page again.